### PR TITLE
Add isJumping flag true in `jump(to:animated)`

### DIFF
--- a/Sources/SwipeMenuView.swift
+++ b/Sources/SwipeMenuView.swift
@@ -277,6 +277,8 @@ open class SwipeMenuView: UIView {
         if currentIndex != index {
             delegate?.swipeMenuView(self, willChangeIndexFrom: currentIndex, to: index)
         }
+
+        isJumping = true
         jumpingToIndex = index
 
         tabView.jump(to: index)


### PR DESCRIPTION
## Summary
call `swipeMenuView.jump(to:animated)`, update of index is executed many times.
https://github.com/abema/SwipeMenuViewController/blob/master/Sources/SwipeMenuView.swift#L399-L411

### Solution
while jumping, set a flag (`isJumping = true`) to not swipe move

## Preview
e.g. call `swipeMenuView.jump(to:animated)`

debug code
```swift
public func scrollViewDidScroll(_ scrollView: UIScrollView) {

    if isJumping || isLayoutingSubviews { return }

    print("scrollView didScroll currentIndex: \(currentIndex)")

    // update currentIndex
        ...
}
```

before
![before](https://user-images.githubusercontent.com/2172769/45483910-4de62400-b78d-11e8-8070-d8a773e656a8.gif)

after
![after](https://user-images.githubusercontent.com/2172769/45483776-e4feac00-b78c-11e8-8e2a-0421a13cf486.gif)