### PR TITLE
Fix isJumping flag enabled

### DIFF
--- a/Sources/SwipeMenuView.swift
+++ b/Sources/SwipeMenuView.swift
@@ -278,7 +278,7 @@ open class SwipeMenuView: UIView {
             delegate?.swipeMenuView(self, willChangeIndexFrom: currentIndex, to: index)
         }
 
-        isJumping = true
+        isJumping = animated
         jumpingToIndex = index
 
         tabView.jump(to: index)


### PR DESCRIPTION
ref: PR https://github.com/abema/SwipeMenuViewController/pull/3

call `swipeMenuView.jump(to:animated)`, synchronize isJumping flag with args.animated state
- jump animation is false, disable isJumping flag
ex. `swipeMenuView.reloadData` 
https://github.com/abema/SwipeMenuViewController/blob/master/Sources/SwipeMenuView.swift#L269