### PR TITLE
Fix currentIndex save timing

### DIFF
--- a/Sources/SwipeMenuView.swift
+++ b/Sources/SwipeMenuView.swift
@@ -419,8 +419,9 @@ extension SwipeMenuView: UIScrollViewDelegate {
 
         if isJumping || isLayoutingSubviews {
             if let toIndex = jumpingToIndex {
-                delegate?.swipeMenuView(self, didChangeIndexFrom: currentIndex, to: toIndex)
+                let fromIndex = currentIndex
                 currentIndex = toIndex
+                delegate?.swipeMenuView(self, didChangeIndexFrom: fromIndex, to: toIndex)
                 jumpingToIndex = nil
             }
             isJumping = false


### PR DESCRIPTION
`currentIndex`を変更するタイミングが `didChangeIndexFrom`の `delegate`を呼んだ後だったので先に変更する。

スクロールをしてタブが変更された時に呼ばれる `didChangeIndexFrom`とタブをタップした時に呼ばれる `didChangeIndexFrom`の両方で、同じ動きをしても`currentIndex`の値が違っていたため、合わせた。

abema-iosで `didChangeIndexFrom`が呼ばれる度に `didChangeCategory`を変更しているが、それをObserveした時には `didChangeIndexFrom`で返ってくる値の `toIndex`からでは無く `currentIndex`から値を取得しなければいけないためこのような変更を行った。