### PR TITLE
fix: reg exp in podspec

### DIFF
--- a/SwipeMenuViewController.podspec
+++ b/SwipeMenuViewController.podspec
@@ -91,7 +91,7 @@ Pod::Spec.new do |s|
   #  Not including the public_header_files will make all headers public.
   #
 
-  s.source_files  = 'Sources/**/*'
+  s.source_files  = 'Sources/**/*.{swift}'
   # s.exclude_files = "Classes/Exclude"
 
   # s.public_header_files = 'Sources/**/*.h'


### PR DESCRIPTION
## Overview
Added`.{swift}` into `source_files` in podspec.
Without `.{swift}` , cocoapods attempt to copy almost all files in that directories, them it'll occur an error (multiple commands produce) in case of containing a plist file.

## TODO
bump up tag